### PR TITLE
Site copy typo fixes and FAQ copy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -78,7 +78,7 @@ This code of conduct and its related procedures also applies to unacceptable beh
 
 ### 10. License and attribution
 
-The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
+The Citizen Code of Conduct is distributed by Stumptown Syndicate under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
 
 Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
 
@@ -88,4 +88,4 @@ _Revision 2.2. Posted 4 February 2016._
 
 _Revision 2.1. Posted 23 June 2014._
 
-_Revision 2.0, adopted by the [Stumptown Syndicate](http://stumptownsyndicate.org) board on 10 January 2013. Posted 17 March 2013._
+_Revision 2.0, adopted by the Stumptown Syndicate board on 10 January 2013. Posted 17 March 2013._

--- a/faq.html
+++ b/faq.html
@@ -11,67 +11,129 @@ title: Frequently Asked Questions
   <p>Python is a high-level, open source, interpreted programming language known for its simplicity and readability. It's widely used in various fields like web development, data science, artificial intelligence, and more.
 </div>
 
+<span class="nhsuk-details__summary-text"></span>
+    Why is Python used in health and care?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Because Python is open source, multi-purpose, has extensive libraries for statistics, data science, healthcare analytics and wider research. It’s also got a vibrant and helpful community meaning it’s easier to get started with an abundance of free training resources. Python is specifically mentioned in the Goldacre Review as one of the open source tools colleagues in Health and Care should be considering using.
+</div>
 
-<h2>Get Involved in the Community!</h2>
-<p>The NHS Python Community for Healthcare is open to anyone interested in championing the use of Python, programming, and open code in the NHS and healthcare sector.</p>
-<ul class="nhsuk-grid-row nhsuk-card-group">
-    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <div class="nhsuk-card nhsuk-card--clickable">
-            <img class="nhsuk-card__img" src="assets/img/links/min/slack-min.png" alt="NHS Python Community Slack">
-            <div class="nhsuk-card__content">
-                <h2 class="nhsuk-card__heading nhsuk-heading-m">
-                    <a class="nhsuk-card__link" href="https://join.slack.com/t/nhs-pycom/shared_invite/zt-z6h1hszo-3_w68FdalVM2EATVVdgCuw"> Slack channel</a>
-                </h2>
-                <p>Join us on Slack to chat to the community or ask us your questions.</p>
-                <!--<a class="nhsuk-button" href="https://join.slack.com/t/nhs-pycom/shared_invite/zt-z6h1hszo-3_w68FdalVM2EATVVdgCuw" draggable="false">
-              Join
-            </a>-->
-            </div>
-        </div>
-    </li>
-    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <div class="nhsuk-card nhsuk-card--clickable">
-            <img class="nhsuk-card__img" src="assets/img/links/min/linkedin-min.png" alt="NHS Python Community LinkedIn">
-            <div class="nhsuk-card__content">
-                <h2 class="nhsuk-card__heading nhsuk-heading-m">
-                    <a class="nhsuk-card__link" href="https://www.linkedin.com/company/nhs-python-community/posts/"> LinkedIn page</a>
-                </h2>
-                <p>Follow our LinkedIn page to be notified about all our future events.</p>
-                <!--<a class="nhsuk-button" href="https://www.linkedin.com/company/nhs-python-community/posts/" draggable="false">
-                Follow
-            </a>-->
-            </div>
-        </div>
-    </li>
-</ul>
-<ul class="nhsuk-grid-row nhsuk-card-group">
-    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <div class="nhsuk-card nhsuk-card--clickable">
-            <img class="nhsuk-card__img" src="assets/img/links/min/youtube-min.png" alt="NHS Python Community Youtube">
-            <div class="nhsuk-card__content">
-                <h2 class="nhsuk-card__heading nhsuk-heading-m">
-                    <a class="nhsuk-card__link" href="https://www.youtube.com/channel/UC_jacmsGNZQR5BPP7h0EtXw/videos"> YouTube channel</a>
-                </h2>
-                <p>Don't forget to like and subscribe to our YouTube channel.</p>
-                <!--<a class="nhsuk-button" href="https://www.youtube.com/channel/UC_jacmsGNZQR5BPP7h0EtXw/videos" draggable="false">
-                Subscribe
-            </a>-->
-            </div>
-        </div>
-    </li>
-    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <div class="nhsuk-card nhsuk-card--clickable">
-            <img class="nhsuk-card__img" src="assets/img/links/min/github-min.png" alt="NHS Python Community GitHub">
-            <div class="nhsuk-card__content">
-                <h2 class="nhsuk-card__heading nhsuk-heading-m">
-                    <a class="nhsuk-card__link" href="https://github.com/nhs-pycom"> GitHub repository</a>
-                </h2>
-                <p>Fork our repositories on GitHub and use our code.</p>
-                <!--<a class="nhsuk-button" href="https://github.com/nhs-pycom" draggable="false">
-                Fork
-            </a>-->
-            </div>
-        </div>
-    </li>
-</ul>
-<p>Would you like to write a blog post for the Python Community? Contact us at: <a href="mailto:nhspythoncommunity@england.nhs.uk">nhspythoncommunity@england.nhs.uk</a></p>
+<span class="nhsuk-details__summary-text"></span>
+    What is open source?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Open source software like Python, is software which is released under a permissive licence which allows for anyone to freely access, use, modify, and share the source code of the software for any purpose. In practice, this means it is freely available to those in the NHS and beyond, without cost, and has a large user base. While Python itself is open source, you can choose whether (and are strongly encouraged) to release your own code as open source, in line with government policy such as Data Saves Lives, the NHS Service Standard and the Goldacre review.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Why should you learn Python?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+    Learning Python opens doors to a wide range of career opportunities due to its versatility and extensive use in industries like web development, data analysis, machine learning, automation, and scientific computing. Its syntax is clear and easy to understand, making it an excellent language for beginners. Python, along with R, is explicitly mentioned in the Goldacre review.
+    <li>Associated with govt policy documents such as <a href="https://www.gov.uk/government/publications/data-saves-lives-reshaping-health-and-social-care-with-data">Data Saves Lives</a>, encouraging move towards open source tools.</li>
+    <li>Python (or other open source tools), is amongst the first steps to working following <a href="https://nhsdigital.github.io/rap-community-of-practice/">“RAP” (Reproducible Analytical Pipelines)</a> - which is a standard endorsed by the Goldacre Review, Data Saves Lives and the NHS SDE Policy. This promises faster, more robust, reusable and transparent analytical processes.</li>
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Why was the NHS Python Community founded?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>The NHS Python Community was founded to promote collaboration, knowledge sharing, and skill development among Python enthusiasts within the National Health Service (NHS) in the UK. It aims to harness the power of Python to improve healthcare services, perform research, streamline processes, and drive innovation.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Who are the Python Community Team?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>The Python Community Team typically comprises volunteers or designated individuals passionate about Python and committed to fostering a supportive and inclusive environment for Python users. In the case of the NHS Python Community, it consists of healthcare professionals, programmers, and enthusiasts dedicated to leveraging Python for healthcare purposes.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How can Python be used for data analysis in healthcare?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python can be used to analyse large datasets, including patient records, clinical trials, and medical imaging data. Libraries like Pandas, PySpark, NumPy, and SciPy allow healthcare professionals to process, analyse, and visualise data to gain insights that can improve patient outcomes. Python can also be used to present data or analysis outputs in dashboards, for example using Streamlit.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Is Python suitable for developing medical software or applications?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Yes, Python is suitable for developing medical software, especially for data analysis, automation of processes, and prototyping. However, when developing software for medical use, it’s essential to adhere to medical software standards and regulations such as ISO 13485 and ensure robust testing and validation.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Can Python be used for AI and machine learning in healthcare?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Absolutely. Python is a leading language for AI and machine learning. For classic machine learning you can use Scikit-learn, for deep learning (neural networks) there is TensorFlow, Keras, and. PyTorch, Natural Language Processing you can use NLTK and spaCy and for LLMs (e.g. AI chatbots) you can use LangChain - but there are many more than just these!. These tools can be used for predictive modelling, diagnostic tools, personalised medicine, and even developing AI-driven medical devices.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How does Python help in improving patient care?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python can help improve patient care by enabling predictive analytics, automating routine tasks, enhancing decision support systems, and, with the appropriate regulatory approvals, providing personalised treatment recommendations through AI models, ultimately leading to more accurate diagnoses and efficient care. By adopting RAP principles, Python can be used to deliver robust, reproducible analytics and reports that are less prone to copy-paste errors in spreadsheets.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What are the data privacy concerns when using Python in healthcare?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is a tool, and as with any other tool like R or SPSS, patient data must be protected in line with data protection regulations like GDPR in the UK, and project-specific Data Protection Impact Assessments (DPIA). Unlike Excel, when sharing Python scripts, the data is not normally included, although care must be taken with notebooks which can contain output of processes which reveal data. Notebook output can be redacted automatically as part of continuous integration and deployment, as demonstrated by the gov.uk Cookiecutter data science template. 
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What Python libraries are commonly used in healthcare applications?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Common Python libraries in healthcare include:
+    <li>Pandas for data manipulation</li>
+    <li>PySpark for analysing very large datasets</li>
+    <li>NumPy for numerical operations</li>
+    <li>SciPy for scientific computing</li>
+    <li>Matplotlib/Seaborn for data visualisation</li>
+    <li>Scikit-learn for machine learning</li>
+    <li>TensorFlow/Keras/PyTorch for deep learning</li>
+    <li>NLTK/spaCy for Natural Language Processing (NLP)</li>
+    <li>PyMC for Bayesian Statistics</li>
+    <li>StatsModels for Statistics (such as forecasting)</li>
+    <li>LangChain for LLMs</li>
+    <li>PyMedTermino for medical terminology management</li>
+    <li>NiBabel for neuroimaging data</li>
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Are there any examples of Python being used in the NHS or UK healthcare system?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is used in various NHS projects, including data analysis, predictive analytics for patient outcomes, and developing AI models for disease diagnosis and resource management. For example, Python has been used in predictive models to manage hospital bed capacity during the COVID-19 pandemic.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Can Python be integrated with existing healthcare systems?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Yes, Python can be integrated with existing healthcare systems, such as Electronic Health Records (EHR) systems, using APIs and libraries like FHIR (Fast Healthcare Interoperability Resources). This allows Python applications to interact with other healthcare software, facilitating data exchange and system interoperability.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What are the challenges of using Python in healthcare?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Some challenges include ensuring compliance with healthcare regulations, managing data privacy, the need for high-performance computing for large datasets, and the need for thorough validation and testing of Python applications to ensure they are safe and effective for clinical use.
+</div>

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,68 @@
+---
+layout: default
+title: Get Involved in the Community!
+---
+
+<h2>Get Involved in the Community!</h2>
+<p>The NHS Python Community for Healthcare is open to anyone interested in championing the use of Python, programming, and open code in the NHS and healthcare sector.</p>
+<ul class="nhsuk-grid-row nhsuk-card-group">
+    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <div class="nhsuk-card nhsuk-card--clickable">
+            <img class="nhsuk-card__img" src="assets/img/links/min/slack-min.png" alt="NHS Python Community Slack">
+            <div class="nhsuk-card__content">
+                <h2 class="nhsuk-card__heading nhsuk-heading-m">
+                    <a class="nhsuk-card__link" href="https://join.slack.com/t/nhs-pycom/shared_invite/zt-z6h1hszo-3_w68FdalVM2EATVVdgCuw"> Slack channel</a>
+                </h2>
+                <p>Join us on Slack to chat to the community or ask us your questions.</p>
+                <!--<a class="nhsuk-button" href="https://join.slack.com/t/nhs-pycom/shared_invite/zt-z6h1hszo-3_w68FdalVM2EATVVdgCuw" draggable="false">
+              Join
+            </a>-->
+            </div>
+        </div>
+    </li>
+    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <div class="nhsuk-card nhsuk-card--clickable">
+            <img class="nhsuk-card__img" src="assets/img/links/min/linkedin-min.png" alt="NHS Python Community LinkedIn">
+            <div class="nhsuk-card__content">
+                <h2 class="nhsuk-card__heading nhsuk-heading-m">
+                    <a class="nhsuk-card__link" href="https://www.linkedin.com/company/nhs-python-community/posts/"> LinkedIn page</a>
+                </h2>
+                <p>Follow our LinkedIn page to be notified about all our future events.</p>
+                <!--<a class="nhsuk-button" href="https://www.linkedin.com/company/nhs-python-community/posts/" draggable="false">
+                Follow
+            </a>-->
+            </div>
+        </div>
+    </li>
+</ul>
+<ul class="nhsuk-grid-row nhsuk-card-group">
+    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <div class="nhsuk-card nhsuk-card--clickable">
+            <img class="nhsuk-card__img" src="assets/img/links/min/youtube-min.png" alt="NHS Python Community Youtube">
+            <div class="nhsuk-card__content">
+                <h2 class="nhsuk-card__heading nhsuk-heading-m">
+                    <a class="nhsuk-card__link" href="https://www.youtube.com/channel/UC_jacmsGNZQR5BPP7h0EtXw/videos"> YouTube channel</a>
+                </h2>
+                <p>Don't forget to like and subscribe to our YouTube channel.</p>
+                <!--<a class="nhsuk-button" href="https://www.youtube.com/channel/UC_jacmsGNZQR5BPP7h0EtXw/videos" draggable="false">
+                Subscribe
+            </a>-->
+            </div>
+        </div>
+    </li>
+    <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <div class="nhsuk-card nhsuk-card--clickable">
+            <img class="nhsuk-card__img" src="assets/img/links/min/github-min.png" alt="NHS Python Community GitHub">
+            <div class="nhsuk-card__content">
+                <h2 class="nhsuk-card__heading nhsuk-heading-m">
+                    <a class="nhsuk-card__link" href="https://github.com/nhs-pycom"> GitHub repository</a>
+                </h2>
+                <p>Fork our repositories on GitHub and use our code.</p>
+                <!--<a class="nhsuk-button" href="https://github.com/nhs-pycom" draggable="false">
+                Fork
+            </a>-->
+            </div>
+        </div>
+    </li>
+</ul>
+<p>Would you like to write a blog post for the Python Community? Contact us at: <a href="mailto:nhspythoncommunity@england.nhs.uk">nhspythoncommunity@england.nhs.uk</a></p>

--- a/faq.html
+++ b/faq.html
@@ -137,3 +137,213 @@ title: Frequently Asked Questions
 <div class="nhsuk-details__text">
   <p>Some challenges include ensuring compliance with healthcare regulations, managing data privacy, the need for high-performance computing for large datasets, and the need for thorough validation and testing of Python applications to ensure they are safe and effective for clinical use.
 </div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How can healthcare professionals learn Python?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Healthcare professionals can learn Python through online courses, tutorials, and workshops tailored to beginners or those with a focus on healthcare applications. There are also Python communities and forums where they can seek help and share knowledge.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What role does Python play in healthcare research?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is widely used in healthcare research for data analysis, bioinformatics, statistical modelling, and developing research tools. It supports reproducibility in research due to its open-source nature and the extensive documentation available.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Are there any ethical considerations when using Python in healthcare?  
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Ethical considerations include ensuring data privacy, informed consent when using patient data, transparency in AI algorithms, and avoiding biases in machine learning models that could lead to unequal treatment of patients.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What is the future of Python in healthcare?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>The future of Python in healthcare looks promising, with growing adoption in AI, machine learning, personalised medicine, and telemedicine. As the healthcare industry continues to digitise, Python’s role in driving innovation and improving patient care will likely expand.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How can Python be used for automating healthcare workflows?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python can be used to automate repetitive tasks such as appointment scheduling, patient record management, billing, and generating reports. Automation tools like Python scripts can reduce manual errors, save time, and improve efficiency in healthcare settings.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What are the benefits of using Python for healthcare data visualisation?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python provides powerful libraries like Matplotlib, Seaborn, and Plotly for creating detailed and interactive visualisations. These tools help healthcare professionals to better understand complex data, identify trends, and communicate findings effectively to both clinical teams and patients.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Can Python be used in the development of wearable healthcare devices?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Yes, Python can be used in the development and data processing aspects of wearable healthcare devices. Python can handle the data collected from these devices, perform real-time analysis, and integrate with other healthcare systems to monitor patient health continuously.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How does Python support interoperability in healthcare IT systems?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python supports interoperability by offering libraries and tools that comply with standards like HL7 and FHIR, which facilitate the integration and communication between different healthcare systems, allowing for seamless data exchange and coordinated care.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How can Python be used to improve patient engagement?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python can be used to develop patient engagement tools, such as mobile apps and chatbots, that provide personalised health information, reminders for medication, and tracking of health metrics. These tools can enhance patient involvement in their own care and improve adherence to treatment plans.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What are the challenges in using Python for clinical decision support systems?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Challenges include ensuring that the decision support systems are based on accurate and up-to-date data, addressing the complexity of integrating these systems into existing clinical workflows, and meeting regulatory requirements to ensure patient safety and efficacy.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How is Python used in predictive analytics for healthcare?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is used in predictive analytics to analyse historical healthcare data and build models that predict future outcomes, such as patient risk of readmission, disease outbreaks, or the likelihood of a patient developing a certain condition. These predictions can inform, with appropriate regulatory oversight, proactive care and resource allocation.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Is Python suitable for handling big data in healthcare?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Yes, Python is suitable for handling big data in healthcare, particularly when combined with tools like Apache Spark or Dask, which allow for distributed data processing. Python’s scalability and the ability to integrate with big data platforms make it ideal for managing and analysing vast amounts of healthcare data.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What are some best practices for using Python in healthcare research?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Best practices include maintaining thorough documentation, ensuring code reproducibility, adhering to ethical guidelines for data usage, and employing version control systems. Additionally, rigorous validation of models and scripts is crucial to ensure accuracy and reliability in research outcomes. Much of this is described in the RAP (Reproducible Analytical Pipelines) way for working, which is endorsed by the Goldacre Review and NHS SDE policy document.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What is the role of Python in health economics?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is used in health economics for cost-effectiveness analysis, modelling healthcare interventions, and conducting statistical analyses of health outcomes. It helps in making data-driven decisions about resource allocation and healthcare policies.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Are there Python resources specifically for healthcare professionals?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Yes, there are numerous resources, including online courses, tutorials, and books tailored to healthcare professionals interested in learning Python. Additionally, many libraries and tools are specifically designed for healthcare applications, with extensive documentation and community support.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Are there Python resources specifically for healthcare professionals?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Yes, there are numerous resources, including online courses, tutorials, and books tailored to healthcare professionals interested in learning Python. Additionally, many libraries and tools are specifically designed for healthcare applications, with extensive documentation and community support.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How can Python improve healthcare logistics and supply chain management?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python can be used to optimise healthcare logistics by analysing supply chain data, predicting demand for medical supplies, and automating inventory management. This can reduce waste, lower costs, and ensure that necessary resources are available when needed.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    What role does Python play in the analysis of electronic health records (EHRs)?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is commonly used to analyse EHRs for trends, outcomes, and patient management. It helps in processing large volumes of data, extracting meaningful insights, and identifying areas for improvement in patient care and operational efficiency.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Can Python be used to ensure regulatory compliance in healthcare software?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python can be used to build and test healthcare software that complies with regulations like GDPR, HIPAA, and medical device standards. Tools and frameworks are available to help ensure that applications meet the required standards for data protection, security, and patient safety.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How can Python help in healthcare fraud detection?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python can be used to develop models and algorithms that detect fraudulent activities in healthcare, such as insurance fraud or billing anomalies. By analysing patterns in large datasets, Python-based systems can identify suspicious activities and reduce the incidence of fraud.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How to get Started with Python?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Our <a href="https://nhs-pycom.net/">NHS Python Community</a> is the perfect starting point. Have a look at our training resources, including interactive training and free Python books, and then consider joining one of our community spaces, reaching out, asking what people are working on and perhaps getting involved in a community project.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How can I improve my Python skills?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Following a framework can really help you know what to focus on as you improve – consider following the “Reproducible Analytical Pipelines” (RAP) framework, endorsed by government policy and used across the civil service. There is an NHS RAP Community of Practice which is full of guidance to help you reach baseline, silver then gold level RAP, making it clear what you need to learn, and the benefits it will bring to you, your team and your work.
+</div>
+
+<!-- To check with Mark Bailey -->
+
+<span class="nhsuk-details__summary-text"></span>
+    Is Python suitable for real-time applications in healthcare?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>While Python can be used for real-time data processing, it may not be the best choice for high-frequency real-time applications due to its performance limitations. However, it can be used effectively in scenarios where real-time processing requirements are moderate, such as monitoring patient vital signs.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    Can Python be used in telemedicine applications?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is well-suited for telemedicine applications, including the development of remote monitoring tools, video consultation platforms, and data integration systems. Python can help ensure these applications are secure, scalable, and capable of integrating with other healthcare IT systems.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How can Python assist in mental health care?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python can be used to develop mental health assessment tools, analyse patient data to detect patterns or risks, and create chatbots or apps that provide, with appropriate regulatory governance, cognitive behavioural therapy (CBT) and other mental health support. These tools can make mental health services more accessible and personalised.
+</div>
+
+<span class="nhsuk-details__summary-text"></span>
+    How does Python facilitate personalised medicine?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python enables personalised medicine by supporting the analysis of genetic data, patient records, and other health information to tailor treatments to individual patients. Machine learning models built with Python can predict how a patient will respond to a specific treatment, leading to more effective and personalised care.
+</div>

--- a/faq.html
+++ b/faq.html
@@ -1,7 +1,16 @@
 ---
 layout: default
-title: Get Involved in the Community!
+title: Frequently Asked Questions
 ---
+
+<span class="nhsuk-details__summary-text">
+    What is Python?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is a high-level, open source, interpreted programming language known for its simplicity and readability. It's widely used in various fields like web development, data science, artificial intelligence, and more.
+</div>
+
 
 <h2>Get Involved in the Community!</h2>
 <p>The NHS Python Community for Healthcare is open to anyone interested in championing the use of Python, programming, and open code in the NHS and healthcare sector.</p>

--- a/get-involved.html
+++ b/get-involved.html
@@ -4,6 +4,15 @@ title: Get Involved in the Community!
 ---
 
 <h2>Get Involved in the Community!</h2>
+
+<span class="nhsuk-details__summary-text">
+    What is Python?
+  </span>
+</summary>
+<div class="nhsuk-details__text">
+  <p>Python is a high-level, open source, interpreted programming language known for its simplicity and readability. It's widely used in various fields like web development, data science, artificial intelligence, and more.
+</div>
+
 <p>The NHS Python Community for Healthcare is open to anyone interested in championing the use of Python, programming, and open code in the NHS and healthcare sector.</p>
 <ul class="nhsuk-grid-row nhsuk-card-group">
     <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">

--- a/get-involved.html
+++ b/get-involved.html
@@ -5,14 +5,6 @@ title: Get Involved in the Community!
 
 <h2>Get Involved in the Community!</h2>
 
-<span class="nhsuk-details__summary-text">
-    What is Python?
-  </span>
-</summary>
-<div class="nhsuk-details__text">
-  <p>Python is a high-level, open source, interpreted programming language known for its simplicity and readability. It's widely used in various fields like web development, data science, artificial intelligence, and more.
-</div>
-
 <p>The NHS Python Community for Healthcare is open to anyone interested in championing the use of Python, programming, and open code in the NHS and healthcare sector.</p>
 <ul class="nhsuk-grid-row nhsuk-card-group">
     <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">

--- a/get-involved.html
+++ b/get-involved.html
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: Get Involved in the Communtiy!
+title: Get Involved in the Community!
 ---
 
-<h2>Get Involved in the Communtiy!</h2>
+<h2>Get Involved in the Community!</h2>
 <p>The NHS Python Community for Healthcare is open to anyone interested in championing the use of Python, programming, and open code in the NHS and healthcare sector.</p>
 <ul class="nhsuk-grid-row nhsuk-card-group">
     <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">


### PR DESCRIPTION
Within the Code of Conduct, the direct link to http://stumptownsyndicate.org should be removed, seems to be redirecting somewhere precarious.

On Get Involved have added a few typo fixes.

I haven't created link within the navigation to the new FAQ page yet, but will give us something to revise first and then we can publish as we consider how to tie tin the 'Guide for User' and 'Guide for IT'.

Thanks!

